### PR TITLE
Replace inline space character

### DIFF
--- a/styles.scss
+++ b/styles.scss
@@ -24,14 +24,14 @@
   display: none;
 }
 .cm-tab::before {
-  content: '→'
+  content: '→';
 }
 [class*=cm-trailing-space]::before {
   content: "·";
 }
 
 $maximum: 16;
-$spaceChar: '.';
+$spaceChar: '·';
 $spaceChars: '';
 @for $i from 1 through $maximum {
   $spaceChars: $spaceChars + $spaceChar;


### PR DESCRIPTION
used to be `.`, replaced with `·` to match trailing whitespace character