### PR TITLE
Add settings and added extra styles for single/trailing spaces

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -152,7 +152,6 @@ class CMShowWhitespacePluginSettingTab extends PluginSettingTab {
       )
       .addToggle((toggle) =>
         toggle.setValue(this.plugin.settings.showSpace).onChange(async (value) => {
-          console.log('show space has changed', value);
           this.plugin.settings.showSpace = value;
           this.plugin.settings.showSingleSpace = value;
           await this.plugin.saveSettings();
@@ -164,7 +163,6 @@ class CMShowWhitespacePluginSettingTab extends PluginSettingTab {
       .setDesc('Show or hide single space characters')
       .addToggle((toggle) => {
         toggle.setValue(this.plugin.settings.showSingleSpace).onChange(async (value) => {
-          console.log('show single space has changed', value);
           this.plugin.settings.showSingleSpace = value;
           await this.plugin.saveSettings();
         });
@@ -179,7 +177,6 @@ class CMShowWhitespacePluginSettingTab extends PluginSettingTab {
       .setDesc('Show or hide trailing space characters')
       .addToggle((toggle) =>
         toggle.setValue(this.plugin.settings.showTrailingSpace).onChange(async (value) => {
-          console.log('show trailing space has changed', value);
           this.plugin.settings.showTrailingSpace = value;
           await this.plugin.saveSettings();
         })
@@ -191,7 +188,6 @@ class CMShowWhitespacePluginSettingTab extends PluginSettingTab {
       .setDesc('Show or hide the newline character')
       .addToggle((toggle) =>
         toggle.setValue(this.plugin.settings.showNewline).onChange(async (value) => {
-          console.log('show newline has changed', value);
           this.plugin.settings.showNewline = value;
           await this.plugin.saveSettings();
         })
@@ -201,7 +197,6 @@ class CMShowWhitespacePluginSettingTab extends PluginSettingTab {
       .setDesc('Show or hide the tab character')
       .addToggle((toggle) =>
         toggle.setValue(this.plugin.settings.showTab).onChange(async (value) => {
-          console.log('show tab has changed', value);
           this.plugin.settings.showTab = value;
           await this.plugin.saveSettings();
         })

--- a/main.ts
+++ b/main.ts
@@ -1,16 +1,35 @@
 import './styles.scss'
 import './cm-show-invisibles'
-import { Plugin, MarkdownView } from 'obsidian';
+import { Plugin, MarkdownView, PluginSettingTab, App, Setting } from 'obsidian';
 
+interface CMShowWhitespacePluginSettings {
+  enabled: boolean;
+  showNewline: boolean;
+  showTab: boolean;
+  showSpace: boolean;
+  showSingleSpace: boolean;
+  showTrailingSpace: boolean;
+}
+
+const DEFAULT_SETTINGS: CMShowWhitespacePluginSettings = {
+  enabled: true,
+  showNewline: true,
+  showTab: true,
+  showSpace: true,
+  showSingleSpace: true,
+  showTrailingSpace: true,
+};
+    
 export default class CMShowWhitespacePlugin extends Plugin {
 
-  settings: any;
+  settings: CMShowWhitespacePluginSettings;
   async onInit() {
     
   }
 
   async onload() {
-    this.settings = await this.loadData() || { enabled: true } as any;
+    await this.loadSettings();
+
     if (this.settings.enabled) {
       (this.app.workspace as any).layoutReady ? this.enable() : this.app.workspace.on('layout-ready', this.enable);
     }
@@ -24,6 +43,8 @@ export default class CMShowWhitespacePlugin extends Plugin {
         this.settings.enabled ? this.disable() : this.enable();
       }
     });
+
+    this.addSettingTab(new CMShowWhitespacePluginSettingTab(this.app, this));
   }
 
   onunload() {
@@ -63,5 +84,127 @@ export default class CMShowWhitespacePlugin extends Plugin {
   showInvisibles = (cm: CodeMirror.Editor, enable: boolean = true) => {
     // @ts-ignore
     cm.setOption("showInvisibles", enable);
+  }
+
+  updateHiddenChars = () => {
+    const { showNewline, showSingleSpace, showSpace, showTab, showTrailingSpace } = this.settings;
+    const body = document.body;
+
+    if (showNewline) {
+      body.classList.remove('plugin-cm-show-whitespace-hide-newline');
+    } else {
+      body.classList.add('plugin-cm-show-whitespace-hide-newline');
+    }
+    if (showTab) {
+      body.classList.remove('plugin-cm-show-whitespace-hide-tab');
+    } else {
+      body.classList.add('plugin-cm-show-whitespace-hide-tab');
+    }
+    if (showSpace) {
+      body.classList.remove('plugin-cm-show-whitespace-hide-space');
+    } else {
+      body.classList.add('plugin-cm-show-whitespace-hide-space');
+    }
+    if (showSingleSpace) {
+      body.classList.remove('plugin-cm-show-whitespace-hide-single-space');
+    } else {
+      body.classList.add('plugin-cm-show-whitespace-hide-single-space');
+    }
+    if (showTrailingSpace) {
+      body.classList.remove('plugin-cm-show-whitespace-hide-trailing-space');
+    } else {
+      body.classList.add('plugin-cm-show-whitespace-hide-trailing-space');
+    }
+  }
+
+  async loadSettings() {
+    this.settings = Object.assign(DEFAULT_SETTINGS, await this.loadData());
+  }
+
+  async saveSettings() {
+    await this.saveData(this.settings);
+    this.updateHiddenChars();
+  }
+}
+
+class CMShowWhitespacePluginSettingTab extends PluginSettingTab {
+  plugin: CMShowWhitespacePlugin;
+
+  constructor(app: App, plugin: CMShowWhitespacePlugin) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display(): void {
+    let {
+      containerEl,
+      plugin: { settings },
+    } = this;
+
+    containerEl.empty();
+    containerEl.classList.add('plugin-cm-show-whitespace-settings');
+
+    new Setting(containerEl).setHeading().setName('Spaces');
+    new Setting(containerEl)
+      .setName('Show space characters')
+      .setDesc(
+        'Show or hide the space character. Note: This will also hide single space characters.'
+      )
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.showSpace).onChange(async (value) => {
+          console.log('show space has changed', value);
+          this.plugin.settings.showSpace = value;
+          this.plugin.settings.showSingleSpace = value;
+          await this.plugin.saveSettings();
+          this.display();
+        })
+      );
+    const singleSpaceSetting = new Setting(containerEl)
+      .setName('Show single space characters')
+      .setDesc('Show or hide single space characters')
+      .addToggle((toggle) => {
+        toggle.setValue(this.plugin.settings.showSingleSpace).onChange(async (value) => {
+          console.log('show single space has changed', value);
+          this.plugin.settings.showSingleSpace = value;
+          await this.plugin.saveSettings();
+        });
+      });
+    if (!settings.showSpace) {
+      // if general spaces are off it doesn't make sense to change the setting
+      // to show or hide single spaces between words
+      singleSpaceSetting.setClass('plugin-cm-show-whitespace-disabled');
+    }
+    new Setting(containerEl)
+      .setName('Show trailing space characters')
+      .setDesc('Show or hide trailing space characters')
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.showTrailingSpace).onChange(async (value) => {
+          console.log('show trailing space has changed', value);
+          this.plugin.settings.showTrailingSpace = value;
+          await this.plugin.saveSettings();
+        })
+      );
+
+    new Setting(containerEl).setHeading().setName('Other whitespace characters');
+    new Setting(containerEl)
+      .setName('Show newline characters')
+      .setDesc('Show or hide the newline character')
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.showNewline).onChange(async (value) => {
+          console.log('show newline has changed', value);
+          this.plugin.settings.showNewline = value;
+          await this.plugin.saveSettings();
+        })
+      );
+    new Setting(containerEl)
+      .setName('Show tab characters')
+      .setDesc('Show or hide the tab character')
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.showTab).onChange(async (value) => {
+          console.log('show tab has changed', value);
+          this.plugin.settings.showTab = value;
+          await this.plugin.saveSettings();
+        })
+      );
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -29,6 +29,7 @@ export default class CMShowWhitespacePlugin extends Plugin {
 
   async onload() {
     await this.loadSettings();
+    this.updateHiddenChars();
 
     if (this.settings.enabled) {
       (this.app.workspace as any).layoutReady ? this.enable() : this.app.workspace.on('layout-ready', this.enable);

--- a/styles.scss
+++ b/styles.scss
@@ -1,11 +1,41 @@
 $maximum: 16;
 
+.plugin-cm-show-whitespace-settings {
+  .plugin-cm-show-whitespace-disabled {
+    opacity: 0.6;
+
+    .checkbox-container {
+      cursor: not-allowed;
+      // this is *not* an adequate way to disable an input but it's all we can do right now
+      pointer-events: none;
+    }
+  }
+}
+
 body.plugin-cm-show-whitespace {
 
   /* feel free to override these characters if you want */
   --spaceChar: '·';
+  --trailingSpaceChar: '·';
+  --singleSpaceChar: var(--spaceChar);
   --tabChar: '→';
   --newlineChar: '¬';
+
+  &.plugin-cm-show-whitespace-hide-space {
+    --spaceChar: '';
+  }
+  &.plugin-cm-show-whitespace-hide-tab {
+    --tabChar: '';
+  }
+  &.plugin-cm-show-whitespace-hide-newline {
+    --newlineChar: '';
+  }
+  &.plugin-cm-show-whitespace-hide-single-space {
+    --singleSpaceChar: '';
+  }
+  &.plugin-cm-show-whitespace-hide-trailing-space {
+    --trailingSpaceChar: '';
+  }
 
   // general styling
   .cm-whitespace::before,
@@ -20,7 +50,7 @@ body.plugin-cm-show-whitespace {
   
   // char replacements
   [class*=cm-trailing-space]::before {
-    content: var(--spaceChar);
+    content: var(--trailingSpaceChar);
   }
   
   .cm-tab::before {
@@ -47,12 +77,21 @@ body.plugin-cm-show-whitespace {
   }
 
 
+  .CodeMirror .cm-whitespace-1:not([class*="cm-trailing-space-"])::before {
+    // specify this before the loop to allow styling single spaces differently
+    content: var(--singleSpaceChar);
+  }
   $spaceChar: var(--spaceChar);
-  $spaceChars: $spaceChar;
-  @for $i from 1 through $maximum {
+  $spaceChars: $spaceChar + ' ' + $spaceChar;
+  @for $i from 2 through $maximum {
     .CodeMirror .cm-whitespace-#{$i}:not([class*="cm-trailing-space-"])::before {
       content: #{$spaceChars};
       $spaceChars: $spaceChars + ' ' + $spaceChar;
     }
+  }
+
+  .CodeMirror .cm-whitespace-1:last-of-type::before {
+    // for some reason a single trailing space doesn't get the `cm-trailing-space` class
+    content: var(--trailingSpaceChar);
   }
 }


### PR DESCRIPTION
* Create a settings page to enable configuration on a per character basis
    * The settings for single characters and all spaces are linked because you should only care to modify the single space setting if you're showing spaces in the first place. There is extra logic to account for this.
    * The setting for trailing spaces is kept "unlinked" as it is common to want to show trailing spaces but not other spaces (see #6)
* Added styling for single characters (those in between words) and trailing characters (those at the end of lines)

This will enable people to have different configurations as well as brings it closer in line with how showing whitespace works in code editors like vscode

I referenced the sample plugin for how to create settings [like so](https://github.com/obsidianmd/obsidian-sample-plugin/blob/cfe4d17ce7dd3346af83e5578d87556f97285951/main.ts#L85)

Resolves #6 