### PR TITLE
Add example CSS to override a character

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ You can override the following CSS variables in your custom CSS to use different
   - `--newlineChar`
   - `--strictLineBreakChar`
 
+Example:
+
+```css
+body.plugin-cm-show-whitespace {
+  --strictLineBreakChar: "↲" !important;
+}
+```
+
 ## Installation
 
 ### From within Obsidian


### PR DESCRIPTION
If you don't like the use of `!important` in the rule, another option is to reduce the specificity in https://github.com/deathau/cm-show-whitespace-obsidian/blob/main/styles.scss#L15 from `body.plugin-cm-show-whitespace {` to `.plugin-cm-show-whitespace {`. Then the example CSS doesn't need `!important`. There may be other side effects I'm not aware of, though.